### PR TITLE
brands endpoints, postman collection

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -22,11 +22,13 @@ import authRouter from "./routes/auth.router.js";
 import rolesRouter from "./routes/roles.router.js";
 import countriesRouter from "./routes/countries.router.js";
 import categoriesRouter from "./routes/categories.router.js";
+import brandsRouter from "./routes/brands.router.js";
 app.use("/users", userRouter);
 app.use("/auth", authRouter);
 app.use("/roles", rolesRouter);
 app.use("/countries", countriesRouter);
 app.use("/categories", categoriesRouter);
+app.use("/brands", brandsRouter);
 
 const port = 3001;
 app.listen(port, () => {

--- a/controllers/BrandController.ts
+++ b/controllers/BrandController.ts
@@ -1,0 +1,67 @@
+import type { Request, Response } from 'express';
+import type { BrandService } from '../services/BrandService.js';
+
+export class BrandController {
+  constructor(private brandService: BrandService) {}
+
+  getAllBrands = async (req: Request, res: Response) => {
+    try {
+      const countryCode = req.query.country as string | undefined;
+      const brands = await this.brandService.getAllBrands(countryCode);
+      res.send(brands);
+    } catch (error: any) {
+      res.status(500).send({ error: error?.message ?? 'Internal Server Error' });
+    }
+  };
+
+  getBrandByName = async (req: Request, res: Response) => {
+    try {
+      const brands = await this.brandService.getBrandByName(req.params.name);
+      if (brands.length === 0) return res.status(404).send({ error: 'Brand not found' });
+      res.send(brands);
+    } catch (error: any) {
+      res.status(500).send({ error: error?.message ?? 'Internal Server Error' });
+    }
+  };
+
+  createBrand = async (req: Request, res: Response) => {
+    try {
+      const { name, countryCode } = req.body;
+      if (!name || !countryCode) return res.status(400).send({ error: 'name and countryCode are required' });
+      const brand = await this.brandService.createBrand({ name, countryCode });
+      res.status(201).send(brand);
+    } catch (error: any) {
+      res.status(400).send({ error: error?.message ?? 'Failed to create brand' });
+    }
+  };
+
+  updateBrand = async (req: Request, res: Response) => {
+    try {
+      const { newName } = req.body;
+      if (!newName) return res.status(400).send({ error: 'newName is required' });
+      const brand = await this.brandService.updateBrand(req.params.name, newName);
+      if (brand.length === 0) return res.status(404).send({ error: 'Brand not found' });
+      res.send(brand);
+    } catch (error: any) {
+      res.status(400).send({ error: error?.message ?? 'Failed to update brand' });
+    }
+  };
+
+  deleteBrand = async (req: Request, res: Response) => {
+    try {
+      await this.brandService.deleteBrand(req.params.name);
+      res.status(204).send();
+    } catch (error: any) {
+      res.status(400).send({ error: error?.message ?? 'Failed to delete brand' });
+    }
+  };
+
+  getBrandItems = async (req: Request, res: Response) => {
+    try {
+      const items = await this.brandService.getBrandItems(req.params.name);
+      res.send(items);
+    } catch (error: any) {
+      res.status(500).send({ error: error?.message ?? 'Internal Server Error' });
+    }
+  };
+}

--- a/postman/collections/collection.json
+++ b/postman/collections/collection.json
@@ -1,10 +1,10 @@
 {
   "info": {
-    "_postman_id": "bd6b1f78-58eb-4519-8728-294a4ecb789c",
-    "name": "SoftTopOp DB Mandatory",
+    "_postman_id": "a32d0946-abf3-41a1-944b-f6f4e317bcad",
+    "name": "SoftTopOp DB Mandatory Copy",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "_exporter_id": "52904670",
-    "_collection_link": "https://go.postman.co/collection/52904670-bd6b1f78-58eb-4519-8728-294a4ecb789c?source=collection_link"
+    "_collection_link": "https://go.postman.co/collection/52904670-a32d0946-abf3-41a1-944b-f6f4e317bcad?source=collection_link"
   },
   "item": [
     {
@@ -623,6 +623,67 @@
                 "items"
               ]
             }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "brands",
+      "item": [
+        {
+          "name": "/brands",
+          "request": {
+            "method": "GET",
+            "header": []
+          },
+          "response": []
+        },
+        {
+          "name": "/brands",
+          "request": {
+            "method": "GET",
+            "header": []
+          },
+          "response": []
+        },
+        {
+          "name": "/brands/:name",
+          "request": {
+            "method": "GET",
+            "header": []
+          },
+          "response": []
+        },
+        {
+          "name": "/brands/:name",
+          "request": {
+            "method": "GET",
+            "header": []
+          },
+          "response": []
+        },
+        {
+          "name": "/brands/:name",
+          "request": {
+            "method": "GET",
+            "header": []
+          },
+          "response": []
+        },
+        {
+          "name": "/brands/:name/items",
+          "request": {
+            "method": "GET",
+            "header": []
+          },
+          "response": []
+        },
+        {
+          "name": "/brands?country=:code",
+          "request": {
+            "method": "GET",
+            "header": []
           },
           "response": []
         }

--- a/repositories/composite_repositories/CompositeBrandRepository.ts
+++ b/repositories/composite_repositories/CompositeBrandRepository.ts
@@ -1,0 +1,73 @@
+import { isRepositoriesEnabled } from '../../utils/repository_utils/ErrorHandling.js';
+import type { IBrandRepository } from '../interfaces/IBrandRepository.js';
+import type { Brand } from '../../dtos/brands/Brand.dto.js';
+import type { ClothingItem } from '../../dtos/items/Item.dto.js';
+
+export class CompositeBrandRepository implements IBrandRepository {
+  constructor(private enabledRepos: IBrandRepository[]) {}
+
+  async getAllBrands(countryCode?: string): Promise<Brand[]> {
+    try {
+      isRepositoriesEnabled(this.enabledRepos);
+      const results = await Promise.all(this.enabledRepos.map(repo => repo.getAllBrands(countryCode)));
+      return results.flat();
+    } catch (error) {
+      console.error('Error fetching brands from repositories:', error);
+      throw error;
+    }
+  }
+
+  async getBrandByName(name: string): Promise<Brand[]> {
+    try {
+      isRepositoriesEnabled(this.enabledRepos);
+      const results = await Promise.all(this.enabledRepos.map(repo => repo.getBrandByName(name)));
+      return results.flat();
+    } catch (error) {
+      console.error(`Error fetching brand "${name}" from repositories:`, error);
+      throw error;
+    }
+  }
+
+  async createBrand(data: { name: string; countryCode: string }): Promise<Brand[]> {
+    try {
+      isRepositoriesEnabled(this.enabledRepos);
+      const results = await Promise.all(this.enabledRepos.map(repo => repo.createBrand(data)));
+      return results.flat();
+    } catch (error) {
+      console.error('Error creating brand in repositories:', error);
+      throw error;
+    }
+  }
+
+  async updateBrand(name: string, newName: string): Promise<Brand[]> {
+    try {
+      isRepositoriesEnabled(this.enabledRepos);
+      const results = await Promise.all(this.enabledRepos.map(repo => repo.updateBrand(name, newName)));
+      return results.flat();
+    } catch (error) {
+      console.error(`Error updating brand "${name}" in repositories:`, error);
+      throw error;
+    }
+  }
+
+  async deleteBrand(name: string): Promise<void> {
+    try {
+      isRepositoriesEnabled(this.enabledRepos);
+      await Promise.all(this.enabledRepos.map(repo => repo.deleteBrand(name)));
+    } catch (error) {
+      console.error(`Error deleting brand "${name}" from repositories:`, error);
+      throw error;
+    }
+  }
+
+  async getBrandItems(name: string): Promise<ClothingItem[]> {
+    try {
+      isRepositoriesEnabled(this.enabledRepos);
+      const results = await Promise.all(this.enabledRepos.map(repo => repo.getBrandItems(name)));
+      return results.flat();
+    } catch (error) {
+      console.error(`Error fetching items for brand "${name}" from repositories:`, error);
+      throw error;
+    }
+  }
+}

--- a/repositories/factories/BrandRepositoryFactory.ts
+++ b/repositories/factories/BrandRepositoryFactory.ts
@@ -1,0 +1,23 @@
+import "dotenv/config";
+
+import { PostgresBrandRepository } from '../postgres/PostgresBrandRepository.js';
+import { MongoBrandRepository } from '../mongo/MongoBrandRepository.js';
+import { Neo4jBrandRepository } from '../neo4j/Neo4jBrandRepository.js';
+import { CompositeBrandRepository } from '../composite_repositories/CompositeBrandRepository.js';
+import type { IBrandRepository } from '../interfaces/IBrandRepository.js';
+
+export function brandRepositoryFactory() {
+  const repos: IBrandRepository[] = [];
+
+  const env = process.env.NODE_ENV ?? "dev";
+  const allowedEnvs = ["dev", "test", "prod"];
+  if (!allowedEnvs.includes(env)) {
+    throw new Error(`Invalid NODE_ENV value: ${env}. Expected "dev", "test", or "prod".`);
+  }
+
+  if (process.env[`POSTGRES_ENABLED_${env.toUpperCase()}`] === 'true') repos.push(new PostgresBrandRepository());
+  if (process.env[`MONGO_ENABLED_${env.toUpperCase()}`] === 'true') repos.push(new MongoBrandRepository());
+  if (process.env[`NEO4J_ENABLED_${env.toUpperCase()}`] === 'true') repos.push(new Neo4jBrandRepository());
+
+  return new CompositeBrandRepository(repos);
+}

--- a/repositories/interfaces/IBrandRepository.ts
+++ b/repositories/interfaces/IBrandRepository.ts
@@ -1,0 +1,12 @@
+import type { Brand } from '../../dtos/brands/Brand.dto.js';
+import type { ClothingItem } from '../../dtos/items/Item.dto.js';
+
+export interface IBrandRepository {
+  getAllBrands(countryCode?: string): Promise<Brand[]>;
+  getBrandByName(name: string): Promise<Brand[]>;
+  createBrand(data: { name: string; countryCode: string }): Promise<Brand[]>;
+  updateBrand(name: string, newName: string): Promise<Brand[]>;
+  deleteBrand(name: string): Promise<void>;
+
+  getBrandItems(name: string): Promise<ClothingItem[]>;
+}

--- a/repositories/mongo/MongoBrandRepository.ts
+++ b/repositories/mongo/MongoBrandRepository.ts
@@ -1,0 +1,108 @@
+import { Brand, Country, Item } from '../../database/mongo/models/index.js';
+import { formatClothingItem } from '../../utils/repository_utils/ObjectFormatters.js';
+import type { IBrandRepository } from '../interfaces/IBrandRepository.js';
+import type { Brand as BrandDto } from '../../dtos/brands/Brand.dto.js';
+import type { ClothingItem } from '../../dtos/items/Item.dto.js';
+
+function formatBrand(b: any, country?: any): BrandDto {
+  return {
+    id: b.id,
+    name: b.name,
+    country: country ? { id: country.id, name: country.name, countryCode: country.countryCode } : undefined,
+    fromDatabase: 'mongodb',
+  };
+}
+
+export class MongoBrandRepository implements IBrandRepository {
+  async getAllBrands(countryCode?: string): Promise<BrandDto[]> {
+    try {
+      let brands;
+      if (countryCode) {
+        const country = await Country.findOne({ countryCode: countryCode.toUpperCase() }).lean().exec();
+        if (!country) return [];
+        brands = await Brand.find({ countryId: country._id }).lean().exec();
+        return brands.map(b => formatBrand(b, country));
+      }
+      brands = await Brand.find().lean().exec();
+      const withCountries = await Promise.all(
+        brands.map(async b => {
+          const country = await Country.findOne({ _id: b.countryId }).lean().exec();
+          return formatBrand(b, country);
+        })
+      );
+      return withCountries;
+    } catch (error) {
+      console.error('Error fetching brands from MongoDB:', error);
+      throw new Error('Failed to fetch brands from MongoDB');
+    }
+  }
+
+  async getBrandByName(name: string): Promise<BrandDto[]> {
+    try {
+      const brand = await Brand.findOne({ name }).lean().exec();
+      if (!brand) return [];
+      const country = await Country.findOne({ _id: brand.countryId }).lean().exec();
+      return [formatBrand(brand, country)];
+    } catch (error) {
+      console.error(`Error fetching brand "${name}" from MongoDB:`, error);
+      throw new Error('Failed to fetch brand from MongoDB');
+    }
+  }
+
+  async createBrand(data: { name: string; countryCode: string }): Promise<BrandDto[]> {
+    try {
+      const country = await Country.findOne({ countryCode: data.countryCode.toUpperCase() }).lean().exec();
+      if (!country) throw new Error(`Country with code "${data.countryCode}" not found`);
+      const max = await Brand.findOne().sort({ id: -1 }).lean().exec();
+      const nextId = max ? max.id + 1 : 1;
+      const brand = await Brand.create({ id: nextId, name: data.name, countryId: country._id });
+      return [formatBrand(brand, country)];
+    } catch (error) {
+      console.error('Error creating brand in MongoDB:', error);
+      throw new Error('Failed to create brand in MongoDB');
+    }
+  }
+
+  async updateBrand(name: string, newName: string): Promise<BrandDto[]> {
+    try {
+      const brand = await Brand.findOneAndUpdate({ name }, { name: newName }, { new: true }).lean().exec();
+      if (!brand) return [];
+      const country = await Country.findOne({ _id: brand.countryId }).lean().exec();
+      return [formatBrand(brand, country)];
+    } catch (error) {
+      console.error(`Error updating brand "${name}" in MongoDB:`, error);
+      throw new Error('Failed to update brand in MongoDB');
+    }
+  }
+
+  async deleteBrand(name: string): Promise<void> {
+    try {
+      await Brand.deleteOne({ name }).exec();
+    } catch (error) {
+      console.error(`Error deleting brand "${name}" from MongoDB:`, error);
+      throw new Error('Failed to delete brand from MongoDB');
+    }
+  }
+
+  async getBrandItems(name: string): Promise<ClothingItem[]> {
+    try {
+      const brand = await Brand.findOne({ name }).lean().exec();
+      if (!brand) return [];
+      const items = await Item.find({ brandIds: brand._id }).lean().exec();
+      const withBrands = await Promise.all(
+        items.map(async item => {
+          const brands = await Promise.all(
+            item.brandIds.map((brandId: any) =>
+              Brand.findOne({ _id: brandId }).select('id name').lean().exec()
+            )
+          );
+          return { ...item, brands };
+        })
+      );
+      return withBrands.map(item => ({ ...formatClothingItem(item, 'mongodb'), fromDatabase: 'mongodb' }));
+    } catch (error) {
+      console.error(`Error fetching items for brand "${name}" from MongoDB:`, error);
+      throw new Error('Failed to fetch brand items from MongoDB');
+    }
+  }
+}

--- a/repositories/neo4j/Neo4jBrandRepository.ts
+++ b/repositories/neo4j/Neo4jBrandRepository.ts
@@ -1,0 +1,141 @@
+import { getBrandModel } from '../../database/neo4j/models/index.js';
+import { neogma } from '../../database/neo4j/neogma-client.js';
+import type { IBrandRepository } from '../interfaces/IBrandRepository.js';
+import type { Brand } from '../../dtos/brands/Brand.dto.js';
+import type { ClothingItem } from '../../dtos/items/Item.dto.js';
+
+function formatBrand(b: any, c: any): Brand {
+  return {
+    id: b.id,
+    name: b.name,
+    country: c ? { id: c.id, name: c.name, countryCode: c.countryCode } : undefined,
+    fromDatabase: 'neo4j',
+  };
+}
+
+export class Neo4jBrandRepository implements IBrandRepository {
+  async getAllBrands(countryCode?: string): Promise<Brand[]> {
+    try {
+      const query = countryCode
+        ? `MATCH (b:Brand)-[:IS_FROM]->(c:Country { countryCode: $countryCode }) RETURN b, c`
+        : `MATCH (b:Brand) OPTIONAL MATCH (b)-[:IS_FROM]->(c:Country) RETURN b, c`;
+      const result = await neogma.queryRunner.run(query, countryCode ? { countryCode } : {});
+      return result.records.map(record => {
+        const b = record.get('b').properties;
+        const c = record.get('c')?.properties ?? null;
+        return formatBrand(b, c);
+      });
+    } catch (error) {
+      console.error('Error fetching brands from Neo4j:', error);
+      throw new Error('Failed to fetch brands from Neo4j');
+    }
+  }
+
+  async getBrandByName(name: string): Promise<Brand[]> {
+    try {
+      const result = await neogma.queryRunner.run(
+        `MATCH (b:Brand { name: $name }) OPTIONAL MATCH (b)-[:IS_FROM]->(c:Country) RETURN b, c`,
+        { name }
+      );
+      return result.records.map(record => {
+        const b = record.get('b').properties;
+        const c = record.get('c')?.properties ?? null;
+        return formatBrand(b, c);
+      });
+    } catch (error) {
+      console.error(`Error fetching brand "${name}" from Neo4j:`, error);
+      throw new Error('Failed to fetch brand from Neo4j');
+    }
+  }
+
+  async createBrand(data: { name: string; countryCode: string }): Promise<Brand[]> {
+    try {
+      const countryResult = await neogma.queryRunner.run(
+        `MATCH (c:Country { countryCode: $countryCode }) RETURN c`,
+        { countryCode: data.countryCode }
+      );
+      if (countryResult.records.length === 0) throw new Error(`Country "${data.countryCode}" not found`);
+      const c = countryResult.records[0]!.get('c').properties;
+
+      const maxResult = await neogma.queryRunner.run(`MATCH (b:Brand) RETURN max(b.id) AS maxId`);
+      const maxId = maxResult.records[0]?.get('maxId') ?? 0;
+      const nextId = (maxId as number) + 1;
+
+      const BrandModel = getBrandModel();
+      const brand = await BrandModel.createOne({ id: nextId, name: data.name });
+      await brand.relateTo({ alias: 'country', where: { countryCode: data.countryCode } });
+
+      return [formatBrand({ id: nextId, name: data.name }, c)];
+    } catch (error) {
+      console.error('Error creating brand in Neo4j:', error);
+      throw new Error('Failed to create brand in Neo4j');
+    }
+  }
+
+  async updateBrand(name: string, newName: string): Promise<Brand[]> {
+    try {
+      const result = await neogma.queryRunner.run(
+        `MATCH (b:Brand { name: $name }) OPTIONAL MATCH (b)-[:IS_FROM]->(c:Country) SET b.name = $newName RETURN b, c`,
+        { name, newName }
+      );
+      if (result.records.length === 0) return [];
+      const b = result.records[0]!.get('b').properties;
+      const c = result.records[0]!.get('c')?.properties ?? null;
+      return [formatBrand(b, c)];
+    } catch (error) {
+      console.error(`Error updating brand "${name}" in Neo4j:`, error);
+      throw new Error('Failed to update brand in Neo4j');
+    }
+  }
+
+  async deleteBrand(name: string): Promise<void> {
+    try {
+      await neogma.queryRunner.run(
+        `MATCH (b:Brand { name: $name }) DETACH DELETE b`,
+        { name }
+      );
+    } catch (error) {
+      console.error(`Error deleting brand "${name}" from Neo4j:`, error);
+      throw new Error('Failed to delete brand from Neo4j');
+    }
+  }
+
+  async getBrandItems(name: string): Promise<ClothingItem[]> {
+    try {
+      const result = await neogma.queryRunner.run(`
+        MATCH (i:Item)-[:BELONGS_TO]->(b:Brand { name: $name })
+        OPTIONAL MATCH (i)-[:BELONGS_TO]->(otherBrand:Brand)
+        OPTIONAL MATCH (i)-[:HAS]->(img:Image)
+        OPTIONAL MATCH (i)-[:BELONGS_TO]->(cat:Category)
+        RETURN i,
+               collect(DISTINCT otherBrand) AS brands,
+               collect(DISTINCT img)        AS images,
+               cat
+      `, { name });
+
+      return result.records.map(record => {
+        const i = record.get('i').properties;
+        const cat = record.get('cat')?.properties;
+        const brands = record.get('brands')
+          .filter((b: any) => b !== null)
+          .map((b: any) => ({ id: b.properties.id, name: b.properties.name }));
+        const images = record.get('images')
+          .filter((img: any) => img !== null)
+          .map((img: any) => ({ id: img.properties.id, url: img.properties.url }));
+
+        return {
+          id: Number(i.id),
+          name: i.name,
+          price: i.price ?? null,
+          category: cat?.name ?? 'Unknown',
+          brands,
+          images,
+          fromDatabase: 'neo4j',
+        };
+      });
+    } catch (error) {
+      console.error(`Error fetching items for brand "${name}" from Neo4j:`, error);
+      throw new Error('Failed to fetch brand items from Neo4j');
+    }
+  }
+}

--- a/repositories/postgres/PostgresBrandRepository.ts
+++ b/repositories/postgres/PostgresBrandRepository.ts
@@ -1,0 +1,102 @@
+import { prisma } from '../../database/postgres/prisma-client.js';
+import { formatClothingItem } from '../../utils/repository_utils/ObjectFormatters.js';
+import type { IBrandRepository } from '../interfaces/IBrandRepository.js';
+import type { Brand } from '../../dtos/brands/Brand.dto.js';
+import type { ClothingItem } from '../../dtos/items/Item.dto.js';
+
+function formatBrand(b: any): Brand {
+  return {
+    id: b.id,
+    name: b.name,
+    country: b.country ? { id: b.country.id, name: b.country.name, countryCode: b.country.countryCode } : undefined,
+    fromDatabase: 'postgresql',
+  };
+}
+
+export class PostgresBrandRepository implements IBrandRepository {
+  async getAllBrands(countryCode?: string): Promise<Brand[]> {
+    try {
+      const brands = await prisma.brand.findMany({
+        where: countryCode ? { country: { countryCode } } : {},
+        include: { country: true },
+      });
+      return brands.map(formatBrand);
+    } catch (error) {
+      console.error('Error fetching brands from PostgreSQL:', error);
+      throw new Error('Failed to fetch brands from PostgreSQL');
+    }
+  }
+
+  async getBrandByName(name: string): Promise<Brand[]> {
+    try {
+      const brand = await prisma.brand.findFirst({
+        where: { name },
+        include: { country: true },
+      });
+      if (!brand) return [];
+      return [formatBrand(brand)];
+    } catch (error) {
+      console.error(`Error fetching brand "${name}" from PostgreSQL:`, error);
+      throw new Error('Failed to fetch brand from PostgreSQL');
+    }
+  }
+
+  async createBrand(data: { name: string; countryCode: string }): Promise<Brand[]> {
+    try {
+      const country = await prisma.country.findFirst({ where: { countryCode: data.countryCode } });
+      if (!country) throw new Error(`Country with code "${data.countryCode}" not found`);
+      const brand = await prisma.brand.create({
+        data: { name: data.name, countryId: country.id },
+        include: { country: true },
+      });
+      return [formatBrand(brand)];
+    } catch (error) {
+      console.error('Error creating brand in PostgreSQL:', error);
+      throw new Error('Failed to create brand in PostgreSQL');
+    }
+  }
+
+  async updateBrand(name: string, newName: string): Promise<Brand[]> {
+    try {
+      const existing = await prisma.brand.findFirst({ where: { name } });
+      if (!existing) return [];
+      const brand = await prisma.brand.update({
+        where: { id: existing.id },
+        data: { name: newName },
+        include: { country: true },
+      });
+      return [formatBrand(brand)];
+    } catch (error) {
+      console.error(`Error updating brand "${name}" in PostgreSQL:`, error);
+      throw new Error('Failed to update brand in PostgreSQL');
+    }
+  }
+
+  async deleteBrand(name: string): Promise<void> {
+    try {
+      const existing = await prisma.brand.findFirst({ where: { name } });
+      if (!existing) return;
+      await prisma.brand.delete({ where: { id: existing.id } });
+    } catch (error) {
+      console.error(`Error deleting brand "${name}" from PostgreSQL:`, error);
+      throw new Error('Failed to delete brand from PostgreSQL');
+    }
+  }
+
+  async getBrandItems(name: string): Promise<ClothingItem[]> {
+    try {
+      const items = await prisma.item.findMany({
+        where: { itemBrands: { some: { brand: { name } } } },
+        include: {
+          category: true,
+          itemBrands: { include: { brand: true } },
+          images: true,
+        },
+      });
+      return items.map(item => ({ ...formatClothingItem(item, 'postgresql'), fromDatabase: 'postgresql' }));
+    } catch (error) {
+      console.error(`Error fetching items for brand "${name}" from PostgreSQL:`, error);
+      throw new Error('Failed to fetch brand items from PostgreSQL');
+    }
+  }
+}

--- a/routes/brands.router.ts
+++ b/routes/brands.router.ts
@@ -1,0 +1,20 @@
+import { Router } from 'express';
+import { brandRepositoryFactory } from '../repositories/factories/BrandRepositoryFactory.js';
+import { BrandService } from '../services/BrandService.js';
+import { BrandController } from '../controllers/BrandController.js';
+
+const router = Router();
+
+const brandRepository = brandRepositoryFactory();
+const brandService = new BrandService(brandRepository);
+const brandController = new BrandController(brandService);
+
+router.get('/', brandController.getAllBrands);
+router.get('/:name', brandController.getBrandByName);
+router.post('/', brandController.createBrand);
+router.patch('/:name', brandController.updateBrand);
+router.delete('/:name', brandController.deleteBrand);
+
+router.get('/:name/items', brandController.getBrandItems);
+
+export default router;

--- a/services/BrandService.ts
+++ b/services/BrandService.ts
@@ -1,0 +1,31 @@
+import type { IBrandRepository } from '../repositories/interfaces/IBrandRepository.js';
+import type { Brand } from '../dtos/brands/Brand.dto.js';
+import type { ClothingItem } from '../dtos/items/Item.dto.js';
+
+export class BrandService {
+  constructor(private brandRepository: IBrandRepository) {}
+
+  async getAllBrands(countryCode?: string): Promise<Brand[]> {
+    return await this.brandRepository.getAllBrands(countryCode);
+  }
+
+  async getBrandByName(name: string): Promise<Brand[]> {
+    return await this.brandRepository.getBrandByName(name);
+  }
+
+  async createBrand(data: { name: string; countryCode: string }): Promise<Brand[]> {
+    return await this.brandRepository.createBrand(data);
+  }
+
+  async updateBrand(name: string, newName: string): Promise<Brand[]> {
+    return await this.brandRepository.updateBrand(name, newName);
+  }
+
+  async deleteBrand(name: string): Promise<void> {
+    await this.brandRepository.deleteBrand(name);
+  }
+
+  async getBrandItems(name: string): Promise<ClothingItem[]> {
+    return await this.brandRepository.getBrandItems(name);
+  }
+}


### PR DESCRIPTION
This pull request introduces a complete "Brand" feature to the backend, enabling CRUD operations and item queries for brands across multiple databases (PostgreSQL, MongoDB, Neo4j). It implements a repository pattern with a composite repository and factory for flexible multi-database support, adds API endpoints and controllers, and updates the Postman collection for testing.

**Brand feature implementation:**

* Added `BrandController` with endpoints for listing, retrieving, creating, updating, and deleting brands, as well as fetching items for a brand. (`controllers/BrandController.ts`)
* Registered the new `/brands` route in the main application file. (`app.ts`)

**Repository layer and database support:**

* Introduced a repository interface (`IBrandRepository`) and implemented it for PostgreSQL, MongoDB, and Neo4j, each supporting all required brand operations. (`repositories/interfaces/IBrandRepository.ts`, `repositories/postgres/PostgresBrandRepository.ts`, `repositories/mongo/MongoBrandRepository.ts`, `repositories/neo4j/Neo4jBrandRepository.ts`) [[1]](diffhunk://#diff-dea8536b2cc8770da8abf9c34d87a3984249d829cbf674886e8721f448dcb80aR1-R12) [[2]](diffhunk://#diff-20ccbd2886829caa64dbd2c3db6879d3dfbe291be3704b34961d5141be323b85R1-R102) [[3]](diffhunk://#diff-b960b8f6a24ca27d64f932ba1951b2bcf572069ef357a7ef58f7907dc38be886R1-R108) [[4]](diffhunk://#diff-1775bd6d2b22a6c84538abf06b0bb4b468ce47767b74ecd8d245c56cef2c875dR1-R141)
* Added a composite repository to aggregate results from enabled repositories, and a factory to configure which repositories are active based on environment variables. (`repositories/composite_repositories/CompositeBrandRepository.ts`, `repositories/factories/BrandRepositoryFactory.ts`) [[1]](diffhunk://#diff-72bdc7163fc10030537a1201f307202bcd7944fd5516c3c540ec9ff5df816813R1-R73) [[2]](diffhunk://#diff-6f356e10cf25ff1c5d32d475a2886f954135f0e911c0c19652a3af27f40f1580R1-R23)

**Testing and API documentation:**

* Updated the Postman collection to include all new `/brands` endpoints for easier testing and documentation. (`postman/collections/collection.json`) [[1]](diffhunk://#diff-aa08f42dded828a0b9e85f9263271a45ec7c481e09624559ff7bc8c1549d04b1R630-R690) [[2]](diffhunk://#diff-aa08f42dded828a0b9e85f9263271a45ec7c481e09624559ff7bc8c1549d04b1L3-R7)